### PR TITLE
Improve UML block boundary detection with brace balancing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plantuml-helpers",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plantuml-helpers",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "plantuml-helpers",
   "displayName": "PlantUmlHelpers",
   "description": "Editor extension that helps facilitate editing and creation of PlantUML diagrams",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "publisher": "michael72",
   "type": "module",
   "engines": {

--- a/src/umlBoundary.ts
+++ b/src/umlBoundary.ts
@@ -23,72 +23,109 @@ export function findUmlBoundaries(
 ): UmlBoundary | undefined {
   const lineCount = lines.length;
 
-  // Search backwards for the start of the UML block
+  // Search backwards for the start of the UML block. Braces are balanced on
+  // the way up so that a block already closed above the cursor (e.g. a
+  // preceding `skinparam x { ... }` or `package { ... }`) is not mistaken
+  // for the block enclosing the cursor.
   let startLine = cursorLine;
+  let bracketStart = false;
+  let unmatchedClosers = 0;
   while (startLine >= 0 && startLine < lineCount) {
     const currentLine = lines[startLine];
     /* v8 ignore next @preserve */
     if (currentLine === undefined) break;
     const text = currentLine.trim();
-    const nextLineText = lines[startLine + 1];
-    const nextLine =
-      startLine + 1 < lineCount && nextLineText !== undefined
-        ? nextLineText.trim()
-        : "";
 
-    if (
-      // auto format starting from the start of the document (without start)
-      // or from opening bracket - including that bracket
-      text.startsWith("@startuml") ||
-      text === "```plantuml" ||
-      (withBrackets && (text.includes("{") || nextLine === "{"))
-    ) {
-      if (withBrackets) {
-        if (text === "{") {
-          // add identifier _before_ the opening bracket (like package etc.)
-          startLine -= 1;
-        } else if (nextLine !== "{" && !text.includes("{")) {
-          startLine += 1;
-        }
-      } else {
-        startLine += 1;
-      }
+    if (text.startsWith("@startuml") || text === "```plantuml") {
+      startLine += 1;
       break;
+    }
+
+    if (withBrackets) {
+      const net = _netBraces(text);
+      if (net > 0) {
+        // the identifier naming the block may sit on the line above a bare "{"
+        const prevLineText = startLine > 0 ? lines[startLine - 1] : undefined;
+        const label =
+          text === "{" && prevLineText !== undefined ? prevLineText.trim() : text;
+        if (unmatchedClosers >= net) {
+          // this block is already closed above the cursor - keep searching
+          unmatchedClosers -= net;
+        } else if (!_isStyleBlock(label)) {
+          bracketStart = true;
+          if (text === "{") {
+            // add identifier _before_ the opening bracket (like package etc.)
+            startLine -= 1;
+          }
+          break;
+        }
+        // style blocks (skinparam) hold no diagram content - keep searching
+      } else if (net < 0 && startLine < cursorLine) {
+        // closer above the cursor: its block does not enclose the cursor;
+        // a closer on the cursor line itself still counts as "inside"
+        unmatchedClosers -= net;
+      } else if (
+        net === 0 &&
+        startLine === cursorLine &&
+        startLine + 1 < lineCount &&
+        lines[startLine + 1]?.trim() === "{" &&
+        !_isStyleBlock(text)
+      ) {
+        // cursor on the identifier line directly above the opening bracket
+        bracketStart = true;
+        break;
+      }
     }
     startLine -= 1;
   }
 
+  if (startLine < 0) {
+    return undefined;
+  }
+
   // Search forwards for the end of the UML block
-  let bracketCount = 0;
   let endLine = startLine;
-  while (endLine >= 0 && endLine < lineCount) {
+  let depth = 0;
+  while (endLine < lineCount) {
     const endLineText = lines[endLine];
     /* v8 ignore next @preserve */
     if (endLineText === undefined) break;
     const text = endLineText.trim();
-    if (
-      text === "@enduml" ||
-      text === "```" ||
-      (withBrackets && text.includes("}") && bracketCount === 1)
-    ) {
-      if (!withBrackets || !text.includes("}")) {
-        endLine -= 1;
-      }
+    if (text === "@enduml" || text === "```") {
+      endLine -= 1;
       break;
-    } else if (withBrackets) {
-      if (text.includes("{")) {
-        bracketCount += 1;
-      } else if (text.includes("}")) {
-        bracketCount -= 1;
+    }
+    if (bracketStart) {
+      depth += _netBraces(text);
+      if (depth <= 0 && text.includes("}")) {
+        // closing bracket of the block is included in the selection
+        break;
       }
     }
     endLine += 1;
   }
 
   // Check if we found valid boundaries
-  if (endLine === lineCount || startLine < 0) {
+  if (endLine === lineCount) {
     return undefined;
   }
 
   return { startLine, endLine };
+}
+
+// Style-only blocks contain no diagram content that could be formatted, so
+// they are never selected as the enclosing block.
+function _isStyleBlock(text: string): boolean {
+  return text.toLowerCase().startsWith("skinparam");
+}
+
+// Net brace count of a line: "{" minus "}", ignoring braces in quoted text
+// (e.g. arrow labels) so they cannot unbalance the block detection.
+function _netBraces(line: string): number {
+  const text = line.replace(/"[^"]*"/g, "");
+  return _count(text, "{") - _count(text, "}");
+}
+
+function _count(text: string, char: string): number {
+  return text.split(char).length - 1;
 }

--- a/test/selection.spec.ts
+++ b/test/selection.spec.ts
@@ -81,6 +81,12 @@ describe("findUmlBoundaries", () => {
       expect(result).toEqual({ startLine: 0, endLine: 3 });
     });
 
+    it("should find package with brace on next line when cursor is on the identifier", () => {
+      const lines = ["package MyPackage", "{", "  class A", "}"];
+      const result = findUmlBoundaries(lines, 0, true);
+      expect(result).toEqual({ startLine: 0, endLine: 3 });
+    });
+
     it("should handle nested braces - finds innermost containing block", () => {
       const lines = [
         "package Outer {",
@@ -111,6 +117,69 @@ describe("findUmlBoundaries", () => {
       const lines = ["component MyComponent {", "  [A] -> [B]", "}"];
       const result = findUmlBoundaries(lines, 1, true);
       expect(result).toEqual({ startLine: 0, endLine: 2 });
+    });
+  });
+
+  describe("blocks closed above the cursor", () => {
+    // Diagram with a skinparam block and a package - the whole diagram
+    // should be selected unless the cursor is inside the package block.
+    const lines = [
+      "@startuml Data Flow", // 0
+      "skinparam component {", // 1
+      "  BackgroundColor<<app>> #4A90D9", // 2
+      "}", // 3
+      'package "DB" {', // 4
+      "  [input1] <<input>>", // 5
+      "}", // 6
+      "[app1] <<app>>", // 7
+      "[input1] --> [app1]", // 8
+      "@enduml", // 9
+    ];
+
+    it.each([0, 1, 2, 3, 7, 8])(
+      "should select the whole diagram, not the skinparam or closed package block (cursor=%i)",
+      (cursor) => {
+        const result = findUmlBoundaries(lines, cursor, true);
+        expect(result).toEqual({ startLine: 1, endLine: 8 });
+      }
+    );
+
+    it.each([4, 5, 6])(
+      "should still select the package block when the cursor is inside it (cursor=%i)",
+      (cursor) => {
+        const result = findUmlBoundaries(lines, cursor, true);
+        expect(result).toEqual({ startLine: 4, endLine: 6 });
+      }
+    );
+
+    it("should not stop the forward search at the closing brace of a nested block", () => {
+      const result = findUmlBoundaries(lines, 0, true);
+      expect(result).toEqual({ startLine: 1, endLine: 8 });
+    });
+
+    it("should skip a skinparam block with the brace on the next line", () => {
+      const withNextLineBrace = [
+        "@startuml", // 0
+        "skinparam component", // 1
+        "{", // 2
+        "  BackgroundColor blue", // 3
+        "}", // 4
+        "A -> B", // 5
+        "@enduml", // 6
+      ];
+      const result = findUmlBoundaries(withNextLineBrace, 3, true);
+      expect(result).toEqual({ startLine: 1, endLine: 5 });
+    });
+
+    it("should ignore braces inside quoted labels", () => {
+      const withQuotedBrace = [
+        "@startuml", // 0
+        'A --> B : "set {x}"', // 1
+        "C --> D", // 2
+        "@enduml", // 3
+      ];
+      const result = findUmlBoundaries(withQuotedBrace, 2, true);
+      expect(result).toEqual({ startLine: 1, endLine: 2 });
     });
   });
 


### PR DESCRIPTION
## Summary
Refactored the UML boundary detection algorithm to properly handle nested and closed blocks by tracking brace balance during the backward search. This prevents incorrectly selecting style-only blocks (like `skinparam`) or blocks that are already closed above the cursor position.

## Key Changes
- **Brace balancing during backward search**: Added tracking of unmatched closing braces to distinguish between blocks that enclose the cursor and blocks that are already closed above it
- **Style block detection**: Introduced `_isStyleBlock()` helper to skip `skinparam` blocks, which contain no diagram content worth formatting
- **Quoted text handling**: Added `_netBraces()` helper that ignores braces inside quoted strings (e.g., arrow labels) to prevent false brace counts
- **Improved identifier handling**: Better support for block identifiers on separate lines from opening braces (e.g., `package Name` followed by `{` on next line)
- **Cleaner forward search**: Simplified the forward search logic using the new `_netBraces()` helper for consistent brace counting

## Notable Implementation Details
- The backward search now maintains `unmatchedClosers` counter to track closing braces encountered above the cursor, allowing the algorithm to skip over already-closed blocks
- Quoted text is stripped before counting braces using regex `/"[^"]*"/g` to handle arrow labels and other quoted content
- The algorithm correctly handles both inline braces (`package Name { ... }`) and braces on separate lines
- Added comprehensive test coverage for edge cases including nested blocks, skinparam blocks, and quoted braces in labels

https://claude.ai/code/session_01KJxTjDiSaKzyBKcThmeGU4