### PR TITLE
Add SVG sanitization and security hardening for PlantUML diagrams

### DIFF
--- a/src/plantumlService.ts
+++ b/src/plantumlService.ts
@@ -3,6 +3,7 @@ import * as https from "https";
 import * as http from "http";
 import * as zlib from "zlib";
 import { encodePlantUml } from "./plantumlEncoder.js";
+import { sanitizeSvg } from "./svgSanitizer.js";
 import {
   getServerUrl,
   getServerType,
@@ -33,16 +34,42 @@ export function getRenderMethod(): "get" | "post" {
  * @returns Promise resolving to the SVG content
  */
 export async function fetchSvg(diagramText: string): Promise<string> {
+  let svg: string;
   if (getServerType() === "Local pumlsrv") {
     await ensurePumlsrvRunning();
-    return fetchSvgViaPost(diagramText, true);
+    svg = await fetchSvgViaPost(diagramText, true);
+  } else if (getRenderMethod() === "post") {
+    svg = await fetchSvgViaPost(diagramText, false);
+  } else {
+    svg = await fetchSvgViaGet(diagramText);
   }
+  // The server (and thus its response) is user/workspace-configurable,
+  // so the SVG is untrusted input for the preview webviews.
+  return sanitizeSvg(svg);
+}
 
-  const method = getRenderMethod();
-  if (method === "post") {
-    return fetchSvgViaPost(diagramText, false);
+/**
+ * Resolves a redirect Location header against the URL of the original
+ * request. Relative locations are resolved; redirects that would
+ * downgrade an HTTPS request to plain HTTP (or switch to a non-HTTP
+ * scheme) are rejected.
+ */
+function resolveRedirectUrl(location: string, baseUrl: string): string {
+  const resolved = new URL(location, baseUrl);
+  if (resolved.protocol !== "https:" && resolved.protocol !== "http:") {
+    throw new Error(
+      `PlantUML server redirected to unsupported URL scheme: ${resolved.protocol}`
+    );
   }
-  return fetchSvgViaGet(diagramText);
+  if (
+    new URL(baseUrl).protocol === "https:" &&
+    resolved.protocol !== "https:"
+  ) {
+    throw new Error(
+      "PlantUML server attempted an insecure redirect from HTTPS to HTTP"
+    );
+  }
+  return resolved.toString();
 }
 
 /**
@@ -62,7 +89,13 @@ async function fetchSvgViaGet(diagramText: string): Promise<string> {
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location ?? "";
       if (statusCode >= 300 && statusCode < 400 && location.length > 0) {
-        fetchFromUrl(location).then(resolve).catch(reject);
+        try {
+          fetchFromUrl(resolveRedirectUrl(location, url))
+            .then(resolve)
+            .catch(reject);
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
         return;
       }
 
@@ -150,7 +183,13 @@ async function fetchSvgViaPost(
       const statusCode = response.statusCode ?? 0;
       const location = response.headers.location ?? "";
       if (statusCode >= 300 && statusCode < 400 && location.length > 0) {
-        fetchFromUrl(location).then(resolve).catch(reject);
+        try {
+          fetchFromUrl(resolveRedirectUrl(location, postUrl))
+            .then(resolve)
+            .catch(reject);
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
         return;
       }
 

--- a/src/plantumlService.ts
+++ b/src/plantumlService.ts
@@ -94,6 +94,7 @@ async function fetchSvgViaGet(diagramText: string): Promise<string> {
             .then(resolve)
             .catch(reject);
         } catch (error) {
+          /* v8 ignore next @preserve - resolveRedirectUrl only throws Error */
           reject(error instanceof Error ? error : new Error(String(error)));
         }
         return;
@@ -188,6 +189,7 @@ async function fetchSvgViaPost(
             .then(resolve)
             .catch(reject);
         } catch (error) {
+          /* v8 ignore next @preserve - resolveRedirectUrl only throws Error */
           reject(error instanceof Error ? error : new Error(String(error)));
         }
         return;

--- a/src/previewPanel.ts
+++ b/src/previewPanel.ts
@@ -1,6 +1,7 @@
 /* v8 ignore start - this UI file is not tested */
 
 import * as vscode from "vscode";
+import * as crypto from "crypto";
 
 /**
  * Message handler type for webview messages.
@@ -311,6 +312,7 @@ export class PlantUmlPreviewPanel {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
   <title>PlantUML Preview</title>
   <style>
     body {
@@ -357,13 +359,16 @@ export class PlantUmlPreviewPanel {
     const escapedMessage = message
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
 
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
   <title>PlantUML Preview - Error</title>
   <style>
     body {
@@ -422,13 +427,9 @@ export class PlantUmlPreviewPanel {
 }
 
 function getNonce(): string {
-  let text = "";
-  const possible =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  for (let i = 0; i < 32; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
+  // Must be cryptographically random - the CSP nonce is the only thing
+  // allowing the preview script to run while blocking injected scripts.
+  return crypto.randomBytes(24).toString("base64url");
 }
 
 /* v8 ignore stop */

--- a/src/pumlsrvService.ts
+++ b/src/pumlsrvService.ts
@@ -82,10 +82,10 @@ function getPumlsrvBinDir(): string {
 }
 
 function findPumlsrvBinary(): string | undefined {
-  // Check PATH via 'which'
+  // Check PATH via 'which' (execFileSync avoids spawning a shell)
   try {
     const result = child_process
-      .execSync("which pumlsrv", { encoding: "utf-8", timeout: 5000 })
+      .execFileSync("which", ["pumlsrv"], { encoding: "utf-8", timeout: 5000 })
       .trim();
     if (result && fs.existsSync(result)) {
       return result;

--- a/src/svgSanitizer.ts
+++ b/src/svgSanitizer.ts
@@ -1,0 +1,74 @@
+/**
+ * Sanitizes SVG content received from a PlantUML server before it is
+ * embedded into a webview or the markdown preview.
+ *
+ * The server URL is user- and workspace-configurable, so the SVG response
+ * must be treated as untrusted input. The webview CSP is the primary
+ * defense against script execution; this sanitizer provides
+ * defense-in-depth by stripping active content that has no place in a
+ * rendered diagram:
+ *
+ * - script/foreignObject/iframe/object/embed/form/meta/base/link elements
+ * - event handler attributes (onclick, onload, ...)
+ * - javascript: and non-image data: URLs in href/src-like attributes
+ *
+ * Legitimate PlantUML output (shapes, text, styles, hyperlinks and
+ * embedded data:image URIs) is preserved.
+ */
+
+const DANGEROUS_ELEMENTS = [
+  "script",
+  "foreignObject",
+  "iframe",
+  "object",
+  "embed",
+  "form",
+  "meta",
+  "base",
+  "link",
+].join("|");
+
+// <tag ...>...</tag> pairs of dangerous elements (non-greedy body)
+const PAIRED_ELEMENT_RE = new RegExp(
+  `<\\s*(${DANGEROUS_ELEMENTS})\\b[^>]*>[\\s\\S]*?<\\s*/\\s*\\1\\s*>`,
+  "gi"
+);
+
+// Any leftover opening, self-closing or closing dangerous tag
+const STRAY_TAG_RE = new RegExp(
+  `<\\s*/?\\s*(?:${DANGEROUS_ELEMENTS})\\b[^>]*>`,
+  "gi"
+);
+
+// Event handler attributes: onload="..." / onclick='...' / onerror=x
+const EVENT_HANDLER_ATTR_RE = /\son\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+
+// href/src-like attributes whose value starts with a dangerous scheme.
+// data: is only allowed for images (data:image/...).
+const DANGEROUS_URL_ATTR_RE =
+  /\s(?:href|xlink:href|src|action|formaction)\s*=\s*(?:"\s*(?:javascript:[^"]*|data:(?!image\/)[^"]*)"|'\s*(?:javascript:[^']*|data:(?!image\/)[^']*)'|(?:javascript:|data:(?!image\/))[^\s>]*)/gi;
+
+function stripUntilStable(input: string, pattern: RegExp): string {
+  let previous;
+  let current = input;
+  do {
+    previous = current;
+    current = current.replace(pattern, "");
+  } while (current !== previous);
+  return current;
+}
+
+/**
+ * Removes active content from an SVG string received from the
+ * PlantUML server. The result is safe to embed as inline HTML.
+ *
+ * @param svg The raw SVG response body
+ * @returns The sanitized SVG
+ */
+export function sanitizeSvg(svg: string): string {
+  let result = stripUntilStable(svg, PAIRED_ELEMENT_RE);
+  result = stripUntilStable(result, STRAY_TAG_RE);
+  result = stripUntilStable(result, EVENT_HANDLER_ATTR_RE);
+  result = stripUntilStable(result, DANGEROUS_URL_ATTR_RE);
+  return result;
+}

--- a/test/plantumlService.spec.ts
+++ b/test/plantumlService.spec.ts
@@ -288,6 +288,25 @@ describe("plantumlService", () => {
       expect(mocks.httpGet).not.toHaveBeenCalled();
     });
 
+    it("should reject redirects to non-HTTP URL schemes", async () => {
+      const redirectResponse = createMockResponse(302, "", {
+        location: "file:///etc/passwd",
+      });
+      const mockRequest = createMockRequest();
+
+      mocks.httpsGet.mockImplementation(
+        (_url: unknown, callback: (res: http.IncomingMessage) => void) => {
+          callback(redirectResponse);
+          return mockRequest;
+        }
+      );
+
+      await expect(fetchSvg("@startuml\nA -> B\n@enduml")).rejects.toThrow(
+        "unsupported URL scheme"
+      );
+      expect(mocks.httpGet).not.toHaveBeenCalled();
+    });
+
     it("should resolve relative redirect locations against the server URL", async () => {
       const svgContent = "<svg>relative redirect</svg>";
       const redirectResponse = createMockResponse(302, "", {
@@ -555,6 +574,33 @@ describe("plantumlService", () => {
       expect(result).toBe(svgContent);
       expect(mocks.httpsRequest).toHaveBeenCalled();
       expect(mocks.httpsGet).toHaveBeenCalled();
+    });
+
+    it("should reject invalid redirects in POST mode", async () => {
+      vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((_key: string, defaultValue: string) => {
+          if (_key === "renderMethod") return "post";
+          return defaultValue;
+        }),
+      } as unknown as vscode.WorkspaceConfiguration);
+
+      const redirectResponse = createMockResponse(302, "", {
+        location: "http://evil.test/svg/encoded",
+      });
+      const mockRequest = createMockRequest();
+
+      mocks.httpsRequest.mockImplementation(
+        (_opts: unknown, callback: (res: http.IncomingMessage) => void) => {
+          callback(redirectResponse);
+          return mockRequest;
+        }
+      );
+
+      await expect(fetchSvg("@startuml\nA -> B\n@enduml")).rejects.toThrow(
+        "insecure redirect"
+      );
+      expect(mocks.httpGet).not.toHaveBeenCalled();
+      expect(mocks.httpsGet).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/plantumlService.spec.ts
+++ b/test/plantumlService.spec.ts
@@ -249,6 +249,75 @@ describe("plantumlService", () => {
       expect(callCount).toBe(2);
     });
 
+    it("should sanitize active content out of the fetched SVG", async () => {
+      const svgContent =
+        `<svg onload="alert(1)"><script>alert(2)</script>` +
+        `<text>diagram</text></svg>`;
+      const mockResponse = createMockResponse(200, svgContent);
+      const mockRequest = createMockRequest();
+
+      mocks.httpsGet.mockImplementation(
+        (_url: unknown, callback: (res: http.IncomingMessage) => void) => {
+          callback(mockResponse);
+          emitResponseEvents(mockResponse);
+          return mockRequest;
+        }
+      );
+
+      const result = await fetchSvg("@startuml\nA -> B\n@enduml");
+
+      expect(result).toBe("<svg><text>diagram</text></svg>");
+    });
+
+    it("should reject redirects that downgrade HTTPS to HTTP", async () => {
+      const redirectResponse = createMockResponse(302, "", {
+        location: "http://evil.test/svg/encoded",
+      });
+      const mockRequest = createMockRequest();
+
+      mocks.httpsGet.mockImplementation(
+        (_url: unknown, callback: (res: http.IncomingMessage) => void) => {
+          callback(redirectResponse);
+          return mockRequest;
+        }
+      );
+
+      await expect(fetchSvg("@startuml\nA -> B\n@enduml")).rejects.toThrow(
+        "insecure redirect"
+      );
+      expect(mocks.httpGet).not.toHaveBeenCalled();
+    });
+
+    it("should resolve relative redirect locations against the server URL", async () => {
+      const svgContent = "<svg>relative redirect</svg>";
+      const redirectResponse = createMockResponse(302, "", {
+        location: "/plantuml/svg/other",
+      });
+      const finalResponse = createMockResponse(200, svgContent);
+      const mockRequest = createMockRequest();
+
+      const capturedUrls: string[] = [];
+      mocks.httpsGet.mockImplementation(
+        (url: unknown, callback: (res: http.IncomingMessage) => void) => {
+          capturedUrls.push(url as string);
+          const response =
+            capturedUrls.length === 1 ? redirectResponse : finalResponse;
+          callback(response);
+          if (capturedUrls.length > 1) {
+            emitResponseEvents(response);
+          }
+          return mockRequest;
+        }
+      );
+
+      const result = await fetchSvg("@startuml\nA -> B\n@enduml");
+
+      expect(result).toBe(svgContent);
+      expect(capturedUrls[1]).toBe(
+        "https://www.plantuml.com/plantuml/svg/other"
+      );
+    });
+
     it("should construct correct URL with encoded diagram", async () => {
       const svgContent = "<svg>test</svg>";
       const mockResponse = createMockResponse(200, svgContent);

--- a/test/svgSanitizer.spec.ts
+++ b/test/svgSanitizer.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeSvg } from "../src/svgSanitizer";
+
+describe("sanitizeSvg", () => {
+  it("keeps a typical PlantUML SVG unchanged", () => {
+    const svg =
+      `<?xml version="1.0" encoding="us-ascii" standalone="no"?>` +
+      `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +
+      `contentStyleType="text/css" height="120px" width="200px">` +
+      `<defs/><g><rect fill="#E2E2F0" height="30" width="50" x="10" y="10"/>` +
+      `<text fill="#000000" font-family="sans-serif" font-size="13" x="20" y="30">Alice</text>` +
+      `<path d="M10,50 L100,50" fill="none" style="stroke:#181818;"/>` +
+      `<ellipse cx="50" cy="80" fill="#181818" rx="4" ry="4"/>` +
+      `</g></svg>`;
+    expect(sanitizeSvg(svg)).toBe(svg);
+  });
+
+  it("keeps PlantUML hyperlinks with http(s) targets", () => {
+    const svg = `<svg><a href="https://example.com" xlink:href="https://example.com"><text>link</text></a></svg>`;
+    expect(sanitizeSvg(svg)).toBe(svg);
+  });
+
+  it("keeps embedded data:image URIs", () => {
+    const svg = `<svg><image href="data:image/png;base64,iVBORw0KGgo=" width="10" height="10"/></svg>`;
+    expect(sanitizeSvg(svg)).toBe(svg);
+  });
+
+  it("removes script elements", () => {
+    const svg = `<svg><script>alert(1)</script><text>ok</text></svg>`;
+    expect(sanitizeSvg(svg)).toBe("<svg><text>ok</text></svg>");
+  });
+
+  it("removes unclosed and self-closing script tags", () => {
+    expect(
+      sanitizeSvg(`<svg><script src="https://evil.test/x.js"/></svg>`)
+    ).toBe("<svg></svg>");
+    expect(sanitizeSvg(`<svg><script>alert(1)`)).toBe("<svg>alert(1)");
+  });
+
+  it("removes nested/split script elements", () => {
+    const svg = `<svg><scr<script>ipt>alert(1)</script></svg>`;
+    const result = sanitizeSvg(svg);
+    expect(result).not.toContain("<script");
+    expect(result).not.toContain("</script");
+  });
+
+  it("removes foreignObject elements", () => {
+    const svg = `<svg><foreignObject><iframe src="https://evil.test"></iframe></foreignObject></svg>`;
+    expect(sanitizeSvg(svg)).toBe("<svg></svg>");
+  });
+
+  it("removes iframe, object, embed, form, meta, base and link tags", () => {
+    const svg =
+      `<svg><iframe src="https://evil.test"></iframe>` +
+      `<object data="x"></object><embed src="x">` +
+      `<form action="https://evil.test"></form>` +
+      `<meta http-equiv="refresh" content="0;url=https://evil.test">` +
+      `<base href="https://evil.test/">` +
+      `<link rel="stylesheet" href="https://evil.test/x.css"></svg>`;
+    expect(sanitizeSvg(svg)).toBe("<svg></svg>");
+  });
+
+  it("removes event handler attributes", () => {
+    const svg = `<svg onload="alert(1)"><rect onclick='alert(2)' width="10"/><text onmouseover=alert(3)>hi</text></svg>`;
+    expect(sanitizeSvg(svg)).toBe(
+      `<svg><rect width="10"/><text>hi</text></svg>`
+    );
+  });
+
+  it("removes javascript: URLs in href attributes", () => {
+    const svg = `<svg><a href="javascript:alert(1)"><text>click</text></a></svg>`;
+    const result = sanitizeSvg(svg);
+    expect(result).not.toContain("javascript:");
+    expect(result).toContain("<text>click</text>");
+  });
+
+  it("removes javascript: URLs in xlink:href and unquoted attributes", () => {
+    expect(
+      sanitizeSvg(`<svg><a xlink:href='javascript:alert(1)'>x</a></svg>`)
+    ).not.toContain("javascript:");
+    expect(
+      sanitizeSvg(`<svg><a href=javascript:alert(1)>x</a></svg>`)
+    ).not.toContain("javascript:");
+  });
+
+  it("removes non-image data: URLs", () => {
+    const svg = `<svg><a href="data:text/html,<script>alert(1)</script>">x</a></svg>`;
+    const result = sanitizeSvg(svg);
+    expect(result).not.toContain("data:text/html");
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive security hardening for PlantUML diagram rendering by implementing SVG sanitization, Content Security Policy headers, and safer redirect handling. Since the PlantUML server URL is user/workspace-configurable, the SVG responses must be treated as untrusted input.

## Key Changes

- **SVG Sanitization** (`svgSanitizer.ts`): New module that strips active content from SVG responses including:
  - Dangerous elements: `<script>`, `<foreignObject>`, `<iframe>`, `<object>`, `<embed>`, `<form>`, `<meta>`, `<base>`, `<link>`
  - Event handler attributes (`onclick`, `onload`, etc.)
  - JavaScript URLs (`javascript:` scheme in href/src attributes)
  - Non-image data URLs (preserves legitimate `data:image/*` URIs)
  - Handles nested/split tags through iterative stripping

- **Redirect Security** (`plantumlService.ts`): 
  - Added `resolveRedirectUrl()` to validate and resolve redirect locations
  - Rejects redirects that downgrade HTTPS to HTTP
  - Properly resolves relative redirect paths against the server URL
  - Integrated sanitization into the main `fetchSvg()` function

- **Content Security Policy** (`previewPanel.ts`):
  - Added CSP header (`default-src 'none'; style-src 'unsafe-inline'`) to both preview and error pages
  - Improved nonce generation using cryptographically secure `crypto.randomBytes()` instead of pseudo-random string generation
  - Enhanced HTML escaping to include quotes for attribute context

- **Code Quality** (`pumlsrvService.ts`):
  - Changed `execSync("which pumlsrv")` to `execFileSync("which", ["pumlsrv"])` to avoid shell spawning

## Testing
Comprehensive test suite added for `sanitizeSvg()` covering:
- Preservation of legitimate PlantUML SVG content
- Removal of various attack vectors
- Edge cases like unclosed/self-closing dangerous tags
- Nested and split tag handling

Additional integration tests verify sanitization in the fetch pipeline and redirect security.

## Defense-in-Depth
The webview CSP is the primary defense against script execution; the SVG sanitizer provides defense-in-depth by removing active content that has no legitimate use in diagram rendering.

https://claude.ai/code/session_01L9e4fDgZ6dRqgRq8Z8agj9