### PR TITLE
Add pumlfmt CLI with format/reset commands and install script

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,7 @@ coverage/**
 vsc-extension-quickstart.md
 **/tsconfig*.json
 **/update_script.sh
+install.sh
 **/package-lock.json
 **/*.cpuprofile
 **/*.vsix

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ VS Code as the `pumlfmt` CLI. It works on plain PlantUML files
 code blocks are formatted. Files are modified in place.
 
 ```sh
-pumlfmt format diagram.puml    # Auto Format (fix arrow layout)
-pumlfmt reset  README.md       # Reset arrow directions to defaults
-pumlfmt format --check *.puml  # exit code 1 if a file would change (for CI)
+pumlfmt diagram.puml       # Auto Format (fix arrow layout)
+pumlfmt --reset README.md  # Reset arrow directions to defaults
+pumlfmt --check *.puml     # exit code 1 if a file would change (for CI)
 ```
 
 ### Installation (Linux / macOS)

--- a/README.md
+++ b/README.md
@@ -33,5 +33,39 @@ Commands with key combinations are:
 * Alt-9: swap arrow left / right
 * Alt-0: rotate arrow to right
 
+## Command line interface (`pumlfmt`)
+
+The _Auto Format_ and _Reformat_ commands are also available outside of
+VS Code as the `pumlfmt` CLI. It works on plain PlantUML files
+(`.puml`, `.plantuml`, `.iuml`, `.pu`, `.wsd`) as well as on markdown files
+(`.md`, `.markdown`), where all ```` ```plantuml ````/```` ```puml ````
+code blocks are formatted. Files are modified in place.
+
+```sh
+pumlfmt format diagram.puml    # Auto Format (fix arrow layout)
+pumlfmt reset  README.md       # Reset arrow directions to defaults
+pumlfmt format --check *.puml  # exit code 1 if a file would change (for CI)
+```
+
+### Installation (Linux / macOS)
+
+Requires Node.js >= 20. Either run the install script from a checkout:
+
+```sh
+./install.sh
+```
+
+or download and run it directly (clones the sources to `~/.local/share/pumlfmt`):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/michael72/plantuml-helpers/master/install.sh | bash
+```
+
+The script builds the CLI and places a `pumlfmt` launcher in
+`/usr/local/bin` (if writable, e.g. as root in a Docker container) or
+`~/.local/bin` otherwise. The target directory can be overridden with the
+`BIN_DIR` environment variable, the source/build directory with `PUMLFMT_HOME`.
+
+Alternatively `npm install -g` from a checkout also installs the `pumlfmt` binary.
 
 **Enjoy!**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default [
         Buffer: 'readonly',
         setTimeout: 'readonly',
         clearTimeout: 'readonly',
+        process: 'readonly',
       },
     },
     plugins: {

--- a/install.sh
+++ b/install.sh
@@ -81,5 +81,5 @@ case ":$PATH:" in
      log "  export PATH=\"$BIN_DIR:\$PATH\"" ;;
 esac
 log ""
-log "Usage: pumlfmt format <file.puml|file.md>   # auto-format arrow layout"
-log "       pumlfmt reset  <file.puml|file.md>   # reset arrows to defaults"
+log "Usage: pumlfmt <file.puml|file.md>           # auto-format arrow layout"
+log "       pumlfmt --reset <file.puml|file.md>   # reset arrows to defaults"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Installs the `pumlfmt` CLI (PlantUML formatter from plantuml-helpers)
+# on Linux / macOS.
+#
+# Usage:
+#   ./install.sh                # from a checkout of the repository
+#   curl -fsSL https://raw.githubusercontent.com/michael72/plantuml-helpers/master/install.sh | bash
+#
+# Environment variables:
+#   PUMLFMT_HOME  where to clone/build the sources when not run from a
+#                 checkout (default: ~/.local/share/pumlfmt)
+#   BIN_DIR       where to place the `pumlfmt` launcher
+#                 (default: /usr/local/bin if writable, else ~/.local/bin)
+
+set -euo pipefail
+
+REPO_URL="https://github.com/michael72/plantuml-helpers.git"
+
+log() { printf '%s\n' "$*"; }
+die() { printf 'install.sh: error: %s\n' "$*" >&2; exit 1; }
+
+command -v node >/dev/null 2>&1 || die "node is required (https://nodejs.org, >= 20). On Ubuntu: apt-get install -y nodejs npm"
+command -v npm >/dev/null 2>&1 || die "npm is required. On Ubuntu: apt-get install -y npm"
+
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$NODE_MAJOR" -lt 20 ]; then
+  die "node >= 20 is required (found $(node --version))"
+fi
+
+# Use the surrounding checkout if this script is run from within the
+# repository, otherwise clone (or update) the sources.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" >/dev/null 2>&1 && pwd)"
+if [ -f "$SCRIPT_DIR/package.json" ] && grep -q '"name": "plantuml-helpers"' "$SCRIPT_DIR/package.json"; then
+  SRC_DIR="$SCRIPT_DIR"
+  log "Using sources in $SRC_DIR"
+else
+  SRC_DIR="${PUMLFMT_HOME:-$HOME/.local/share/pumlfmt}"
+  command -v git >/dev/null 2>&1 || die "git is required to fetch the sources. On Ubuntu: apt-get install -y git"
+  if [ -d "$SRC_DIR/.git" ]; then
+    log "Updating sources in $SRC_DIR"
+    git -C "$SRC_DIR" pull --ff-only
+  else
+    log "Cloning $REPO_URL to $SRC_DIR"
+    mkdir -p "$(dirname "$SRC_DIR")"
+    git clone --depth 1 "$REPO_URL" "$SRC_DIR"
+  fi
+fi
+
+log "Installing dependencies..."
+(cd "$SRC_DIR" && npm ci --no-audit --no-fund 2>/dev/null) \
+  || (cd "$SRC_DIR" && npm install --no-audit --no-fund)
+
+log "Compiling..."
+(cd "$SRC_DIR" && npm run compile)
+
+[ -f "$SRC_DIR/out/src/cli.js" ] || die "build did not produce out/src/cli.js"
+
+# Pick the target directory for the launcher.
+if [ -z "${BIN_DIR:-}" ]; then
+  if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
+    BIN_DIR=/usr/local/bin
+  else
+    BIN_DIR="$HOME/.local/bin"
+  fi
+fi
+mkdir -p "$BIN_DIR"
+
+LAUNCHER="$BIN_DIR/pumlfmt"
+cat > "$LAUNCHER" <<EOF
+#!/usr/bin/env bash
+exec node "$SRC_DIR/out/src/cli.js" "\$@"
+EOF
+chmod +x "$LAUNCHER"
+
+log ""
+log "Installed pumlfmt $(node "$SRC_DIR/out/src/cli.js" --version | awk '{print $2}') to $LAUNCHER"
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) log "NOTE: $BIN_DIR is not on your PATH - add it, e.g.:"
+     log "  export PATH=\"$BIN_DIR:\$PATH\"" ;;
+esac
+log ""
+log "Usage: pumlfmt format <file.puml|file.md>   # auto-format arrow layout"
+log "       pumlfmt reset  <file.puml|file.md>   # reset arrows to defaults"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "plantuml-helpers",
       "version": "0.9.2",
       "license": "SEE LICENSE IN LICENSE.txt",
+      "bin": {
+        "pumlfmt": "out/src/cli.js"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/markdown-it": "^14.1.2",
@@ -1148,9 +1151,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1168,9 +1168,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1188,9 +1185,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1208,9 +1202,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,9 +1219,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1248,9 +1236,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4514,9 +4499,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4538,9 +4520,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4562,9 +4541,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4586,9 +4562,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "Other"
   ],
   "main": "./out/src/extension.js",
+  "bin": {
+    "pumlfmt": "./out/src/cli.js"
+  },
   "activationEvents": [
     "onLanguage:markdown",
     "onLanguage:plantuml"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,16 +12,13 @@ import {
   formatPlantUmlContent,
 } from "./cliFormat.js";
 
-const USAGE = `Usage: pumlfmt <command> [options] <file>...
+const USAGE = `Usage: pumlfmt [options] <file>...
 
-Format PlantUML diagrams in .puml files or in \`\`\`plantuml code blocks
-of markdown files. Files are modified in place.
-
-Commands:
-  format    Auto-format the diagrams (fix arrow layout)
-  reset     Reset arrow directions to their defaults, then format
+Auto-formats PlantUML diagrams (fixes the arrow layout) in .puml files or
+in \`\`\`plantuml code blocks of markdown files. Files are modified in place.
 
 Options:
+  -r, --reset    Reset arrow directions to their defaults before formatting
   -c, --check    Do not write; exit with code 1 if a file would change
   -h, --help     Show this help
   -V, --version  Print the version
@@ -65,7 +62,6 @@ function main(argv: string[]): number {
 // stop right away (0 for --help/--version, 2 for usage errors).
 function parseArgs(argv: string[]): CliArgs | number {
   const args: CliArgs = { rebuild: false, check: false, files: [] };
-  let command: string | undefined;
 
   for (const arg of argv) {
     if (arg === "-h" || arg === "--help") {
@@ -74,27 +70,16 @@ function parseArgs(argv: string[]): CliArgs | number {
     } else if (arg === "-V" || arg === "--version") {
       process.stdout.write(`pumlfmt ${readVersion()}\n`);
       return 0;
+    } else if (arg === "-r" || arg === "--reset") {
+      args.rebuild = true;
     } else if (arg === "-c" || arg === "--check") {
       args.check = true;
     } else if (arg.startsWith("-")) {
       process.stderr.write(`pumlfmt: unknown option '${arg}'\n\n${USAGE}`);
       return 2;
-    } else if (command === undefined) {
-      command = arg;
     } else {
       args.files.push(arg);
     }
-  }
-
-  if (command === "reset") {
-    args.rebuild = true;
-  } else if (command !== "format") {
-    const problem =
-      command === undefined
-        ? "missing command"
-        : `unknown command '${command}'`;
-    process.stderr.write(`pumlfmt: ${problem}\n\n${USAGE}`);
-    return 2;
   }
 
   if (args.files.length === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/* v8 ignore start - thin I/O wrapper around cliFormat.ts, which is tested */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  FormatFileResult,
+  MARKDOWN_EXTENSIONS,
+  PLANTUML_EXTENSIONS,
+  formatMarkdownContent,
+  formatPlantUmlContent,
+} from "./cliFormat.js";
+
+const USAGE = `Usage: pumlfmt <command> [options] <file>...
+
+Format PlantUML diagrams in .puml files or in \`\`\`plantuml code blocks
+of markdown files. Files are modified in place.
+
+Commands:
+  format    Auto-format the diagrams (fix arrow layout)
+  reset     Reset arrow directions to their defaults, then format
+
+Options:
+  -c, --check    Do not write; exit with code 1 if a file would change
+  -h, --help     Show this help
+  -V, --version  Print the version
+
+Supported file types:
+  PlantUML:  ${[...PLANTUML_EXTENSIONS].join(", ")}
+  Markdown:  ${[...MARKDOWN_EXTENSIONS].join(", ")} (\`\`\`plantuml / \`\`\`puml blocks)
+`;
+
+interface CliArgs {
+  rebuild: boolean;
+  check: boolean;
+  files: string[];
+}
+
+function main(argv: string[]): number {
+  const args = parseArgs(argv);
+  if (typeof args === "number") {
+    return args;
+  }
+
+  let exitCode = 0;
+  let wouldChange = false;
+
+  for (const file of args.files) {
+    const result = processFile(file, args.rebuild, args.check);
+    if (result === undefined) {
+      exitCode = 1;
+    } else if (result.changed > 0) {
+      wouldChange = true;
+    }
+  }
+
+  if (args.check && wouldChange) {
+    return 1;
+  }
+  return exitCode;
+}
+
+// Returns the parsed arguments, or an exit code when the program should
+// stop right away (0 for --help/--version, 2 for usage errors).
+function parseArgs(argv: string[]): CliArgs | number {
+  const args: CliArgs = { rebuild: false, check: false, files: [] };
+  let command: string | undefined;
+
+  for (const arg of argv) {
+    if (arg === "-h" || arg === "--help") {
+      process.stdout.write(USAGE);
+      return 0;
+    } else if (arg === "-V" || arg === "--version") {
+      process.stdout.write(`pumlfmt ${readVersion()}\n`);
+      return 0;
+    } else if (arg === "-c" || arg === "--check") {
+      args.check = true;
+    } else if (arg.startsWith("-")) {
+      process.stderr.write(`pumlfmt: unknown option '${arg}'\n\n${USAGE}`);
+      return 2;
+    } else if (command === undefined) {
+      command = arg;
+    } else {
+      args.files.push(arg);
+    }
+  }
+
+  if (command === "reset") {
+    args.rebuild = true;
+  } else if (command !== "format") {
+    const problem =
+      command === undefined
+        ? "missing command"
+        : `unknown command '${command}'`;
+    process.stderr.write(`pumlfmt: ${problem}\n\n${USAGE}`);
+    return 2;
+  }
+
+  if (args.files.length === 0) {
+    process.stderr.write(`pumlfmt: no input files\n\n${USAGE}`);
+    return 2;
+  }
+  return args;
+}
+
+// Formats a single file in place. Returns undefined on failure.
+function processFile(
+  file: string,
+  rebuild: boolean,
+  check: boolean
+): FormatFileResult | undefined {
+  const ext = path.extname(file).toLowerCase();
+  let content: string;
+  try {
+    content = fs.readFileSync(file, "utf8");
+  } catch (e) {
+    process.stderr.write(`pumlfmt: ${errorMessage(e)}\n`);
+    return undefined;
+  }
+
+  let result: FormatFileResult;
+  if (MARKDOWN_EXTENSIONS.has(ext)) {
+    result = formatMarkdownContent(content, rebuild);
+  } else if (PLANTUML_EXTENSIONS.has(ext)) {
+    result = formatPlantUmlContent(content, rebuild);
+  } else {
+    process.stderr.write(`pumlfmt: ${file}: unsupported file type '${ext}'\n`);
+    return undefined;
+  }
+
+  for (const warning of result.warnings) {
+    process.stderr.write(`pumlfmt: warning: ${file}: ${warning}\n`);
+  }
+  if (result.found === 0 && result.warnings.length === 0) {
+    process.stderr.write(`pumlfmt: warning: ${file}: no PlantUML found\n`);
+  }
+
+  if (result.changed === 0) {
+    process.stdout.write(`unchanged  ${file}\n`);
+  } else if (check) {
+    process.stdout.write(
+      `would format  ${file} (${diagramCount(result.changed)})\n`
+    );
+  } else {
+    try {
+      fs.writeFileSync(file, result.text, "utf8");
+    } catch (e) {
+      process.stderr.write(`pumlfmt: ${errorMessage(e)}\n`);
+      return undefined;
+    }
+    process.stdout.write(
+      `formatted  ${file} (${diagramCount(result.changed)})\n`
+    );
+  }
+  return result;
+}
+
+function diagramCount(n: number): string {
+  return n === 1 ? "1 diagram" : `${n} diagrams`;
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function readVersion(): string {
+  // package.json is two levels up from out/src/cli.js (or one level up when
+  // running from the sources with tsx).
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  for (const candidate of ["../../package.json", "../package.json"]) {
+    try {
+      const raw = fs.readFileSync(path.join(dir, candidate), "utf8");
+      const pkg = JSON.parse(raw) as { name?: string; version?: string };
+      if (pkg.name === "plantuml-helpers" && pkg.version !== undefined) {
+        return pkg.version;
+      }
+    } catch {
+      // try the next candidate
+    }
+  }
+  return "unknown";
+}
+
+process.exit(main(process.argv.slice(2)));
+
+/* v8 ignore stop */

--- a/src/cliFormat.ts
+++ b/src/cliFormat.ts
@@ -1,0 +1,207 @@
+import { autoFormatTxt } from "./reformat.js";
+
+/** Result of formatting the content of a single file. */
+export interface FormatFileResult {
+  /** The (possibly modified) file content. */
+  text: string;
+  /** Number of PlantUML diagrams found in the file. */
+  found: number;
+  /** Number of diagrams whose content was changed. */
+  changed: number;
+  /** Diagrams that could not be formatted (unsupported type etc.). */
+  warnings: string[];
+}
+
+/** File extensions treated as plain PlantUML files. */
+export const PLANTUML_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".puml",
+  ".plantuml",
+  ".iuml",
+  ".pu",
+  ".wsd",
+]);
+
+/** File extensions treated as markdown files with embedded PlantUML blocks. */
+export const MARKDOWN_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".md",
+  ".markdown",
+]);
+
+// Fence info strings that mark a code block as PlantUML - the same set that
+// the markdown-it plugin renders (see markdownItPlugin.ts).
+const PLANTUML_FENCE_INFOS: ReadonlySet<string> = new Set(["plantuml", "puml"]);
+
+const FENCE_OPEN = /^\s*(`{3,}|~{3,})\s*(\S*)\s*$/;
+
+/**
+ * Formats the content of a PlantUML file.
+ *
+ * If the file contains `@startuml`/`@enduml` sections, each section is
+ * formatted separately and any text outside the sections is left untouched.
+ * Otherwise the whole content is treated as one diagram.
+ */
+export function formatPlantUmlContent(
+  content: string,
+  rebuild = false
+): FormatFileResult {
+  const eol = _eol(content);
+  const lines = content.split(/\r?\n/);
+  const regions = _findUmlRegions(lines);
+
+  if (regions.length === 0) {
+    // bare diagram without @startuml/@enduml markers
+    const result = _emptyResult(content);
+    result.found = 1;
+    result.text = _tryFormat(content, rebuild, result, "diagram");
+    return result;
+  }
+
+  return _formatRegions(lines, regions, eol, rebuild);
+}
+
+/**
+ * Formats all ```plantuml / ```puml fenced code blocks in markdown content.
+ * All other content is left untouched.
+ */
+export function formatMarkdownContent(
+  content: string,
+  rebuild = false
+): FormatFileResult {
+  const eol = _eol(content);
+  const lines = content.split(/\r?\n/);
+  const regions: _Region[] = [];
+
+  let i = 0;
+  while (i < lines.length) {
+    const open = FENCE_OPEN.exec(lines[i] ?? "");
+    i += 1;
+    if (open !== null) {
+      const fence = open[1] ?? "";
+      const info = (open[2] ?? "").toLowerCase();
+      // find the closing fence: same character, at least the same length
+      const close = _findClosingFence(lines, i, fence);
+      if (close < 0) {
+        if (PLANTUML_FENCE_INFOS.has(info)) {
+          const result = _emptyResult(content);
+          result.warnings.push(`unterminated \`\`\`${info} block at line ${i}`);
+          return result;
+        }
+        break;
+      }
+      if (PLANTUML_FENCE_INFOS.has(info) && close > i) {
+        // exclude the fence lines themselves from the region
+        regions.push({ start: i, end: close - 1 });
+      }
+      i = close + 1;
+    }
+  }
+
+  return _formatRegions(lines, regions, eol, rebuild);
+}
+
+interface _Region {
+  /** First line of the diagram (inclusive). */
+  start: number;
+  /** Last line of the diagram (inclusive). */
+  end: number;
+}
+
+function _emptyResult(content: string): FormatFileResult {
+  return { text: content, found: 0, changed: 0, warnings: [] };
+}
+
+// Finds all @startuml ... @enduml sections (markers included in the region -
+// autoFormatTxt handles them and keeps them in place).
+function _findUmlRegions(lines: string[]): _Region[] {
+  const regions: _Region[] = [];
+  let start = -1;
+  lines.forEach((line, idx) => {
+    const trimmed = line.trim().toLowerCase();
+    if (start < 0 && trimmed.startsWith("@startuml")) {
+      start = idx;
+    } else if (start >= 0 && trimmed.startsWith("@enduml")) {
+      regions.push({ start, end: idx });
+      start = -1;
+    }
+  });
+  return regions;
+}
+
+function _findClosingFence(
+  lines: string[],
+  from: number,
+  fence: string
+): number {
+  const fenceChar = fence.charAt(0);
+  for (let i = from; i < lines.length; i++) {
+    const trimmed = (lines[i] ?? "").trim();
+    if (
+      trimmed.length >= fence.length &&
+      trimmed.split("").every((c) => c === fenceChar)
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Formats each region in place (bottom-up so indices stay valid) and joins
+// the lines back together.
+function _formatRegions(
+  lines: string[],
+  regions: _Region[],
+  eol: string,
+  rebuild: boolean
+): FormatFileResult {
+  const result = _emptyResult("");
+  result.found = regions.length;
+
+  for (let r = regions.length - 1; r >= 0; r--) {
+    const region = regions[r];
+    /* v8 ignore next @preserve */
+    if (region !== undefined) {
+      const original = lines.slice(region.start, region.end + 1).join(eol);
+      const formatted = _tryFormat(
+        original,
+        rebuild,
+        result,
+        `diagram at line ${region.start + 1}`
+      );
+      if (formatted !== original) {
+        lines.splice(
+          region.start,
+          region.end - region.start + 1,
+          ...formatted.split(/\r?\n/)
+        );
+      }
+    }
+  }
+
+  result.text = lines.join(eol);
+  return result;
+}
+
+// Formats a single diagram, counting changes and collecting a warning
+// (instead of throwing) when the diagram cannot be formatted.
+function _tryFormat(
+  text: string,
+  rebuild: boolean,
+  result: FormatFileResult,
+  what: string
+): string {
+  try {
+    const formatted = autoFormatTxt(text, rebuild);
+    if (formatted.trim() !== text.trim()) {
+      result.changed += 1;
+      return formatted;
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    result.warnings.push(`${what}: ${message}`);
+  }
+  return text;
+}
+
+function _eol(content: string): string {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}

--- a/src/cliFormat.ts
+++ b/src/cliFormat.ts
@@ -73,10 +73,13 @@ export function formatMarkdownContent(
 
   let i = 0;
   while (i < lines.length) {
+    /* v8 ignore next @preserve - lines[i] is always defined for i < length */
     const open = FENCE_OPEN.exec(lines[i] ?? "");
     i += 1;
     if (open !== null) {
+      /* v8 ignore next @preserve - the capture group always matches */
       const fence = open[1] ?? "";
+      /* v8 ignore next @preserve - the capture group always matches */
       const info = (open[2] ?? "").toLowerCase();
       // find the closing fence: same character, at least the same length
       const close = _findClosingFence(lines, i, fence);
@@ -134,6 +137,7 @@ function _findClosingFence(
 ): number {
   const fenceChar = fence.charAt(0);
   for (let i = from; i < lines.length; i++) {
+    /* v8 ignore next @preserve - lines[i] is always defined for i < length */
     const trimmed = (lines[i] ?? "").trim();
     if (
       trimmed.length >= fence.length &&
@@ -196,6 +200,7 @@ function _tryFormat(
       return formatted;
     }
   } catch (e) {
+    /* v8 ignore next @preserve - autoFormatTxt only throws Error */
     const message = e instanceof Error ? e.message : String(e);
     result.warnings.push(`${what}: ${message}`);
   }

--- a/test/cliFormat.spec.ts
+++ b/test/cliFormat.spec.ts
@@ -169,6 +169,14 @@ describe("formatMarkdownContent", () => {
     expect(result.warnings[0]).toContain("unterminated");
   });
 
+  it("should stop scanning at an unterminated non-plantuml fence", () => {
+    const original = ["```js", "const x = 1;", ""].join("\n");
+    const result = formatMarkdownContent(original);
+    expect(result.text).toBe(original);
+    expect(result.found).toBe(0);
+    expect(result.warnings).toEqual([]);
+  });
+
   it("should skip empty plantuml blocks", () => {
     const original = ["```plantuml", "```", ""].join("\n");
     const result = formatMarkdownContent(original);

--- a/test/cliFormat.spec.ts
+++ b/test/cliFormat.spec.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { formatMarkdownContent, formatPlantUmlContent } from "../src/cliFormat";
+
+describe("formatPlantUmlContent", () => {
+  it("should format a bare diagram without @startuml markers", () => {
+    const original = "[B] -> [C]\n[A] -> [B]\n";
+    const expected = "[A] -> [B]\n[B] -> [C]\n";
+    const result = formatPlantUmlContent(original);
+    expect(result.text).toBe(expected);
+    expect(result.found).toBe(1);
+    expect(result.changed).toBe(1);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("should report an unchanged diagram", () => {
+    const original = "[A] -> [B]\n[B] -> [C]\n";
+    const result = formatPlantUmlContent(original);
+    expect(result.text).toBe(original);
+    expect(result.found).toBe(1);
+    expect(result.changed).toBe(0);
+  });
+
+  it("should format a diagram inside @startuml markers", () => {
+    const original = "@startuml\n[B] -> [C]\n[A] -> [B]\n@enduml\n";
+    // the formatter separates the markers with blank lines
+    const expected = "@startuml\n\n[A] -> [B]\n[B] -> [C]\n\n@enduml\n";
+    const result = formatPlantUmlContent(original);
+    expect(result.text).toBe(expected);
+    expect(result.found).toBe(1);
+    expect(result.changed).toBe(1);
+  });
+
+  it("should format each diagram in a multi-diagram file separately", () => {
+    const original = [
+      "@startuml first",
+      "[B] -> [C]",
+      "[A] -> [B]",
+      "@enduml",
+      "some text in between",
+      "@startuml second",
+      "[Y] -> [Z]",
+      "[X] -> [Y]",
+      "@enduml",
+      "",
+    ].join("\n");
+    const result = formatPlantUmlContent(original);
+    expect(result.found).toBe(2);
+    expect(result.changed).toBe(2);
+    expect(result.text).toContain("some text in between");
+    expect(result.text.indexOf("[A] -> [B]")).toBeLessThan(
+      result.text.indexOf("[B] -> [C]")
+    );
+    expect(result.text.indexOf("[X] -> [Y]")).toBeLessThan(
+      result.text.indexOf("[Y] -> [Z]")
+    );
+  });
+
+  it("should reset arrow directions with rebuild", () => {
+    // autoFormat keeps the explicit downward inheritance, reset rebuilds it
+    const original = "A --|> B";
+    expect(formatPlantUmlContent(original, false).text).toBe("A --|> B");
+    expect(formatPlantUmlContent(original, true).text).toBe("B <|-- A");
+  });
+
+  it("should collect a warning for content that cannot be formatted", () => {
+    const original = "Hello World!\n";
+    const result = formatPlantUmlContent(original);
+    expect(result.text).toBe(original);
+    expect(result.changed).toBe(0);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it("should preserve CRLF line endings", () => {
+    const original = "[B] -> [C]\r\n[A] -> [B]\r\n";
+    const result = formatPlantUmlContent(original);
+    expect(result.text).toBe("[A] -> [B]\r\n[B] -> [C]\r\n");
+  });
+});
+
+describe("formatMarkdownContent", () => {
+  it("should format plantuml code blocks and leave other content alone", () => {
+    const original = [
+      "# Title",
+      "",
+      "```plantuml",
+      "[B] -> [C]",
+      "[A] -> [B]",
+      "```",
+      "",
+      "```js",
+      "const x = 1;",
+      "```",
+      "",
+    ].join("\n");
+    const expected = [
+      "# Title",
+      "",
+      "```plantuml",
+      "[A] -> [B]",
+      "[B] -> [C]",
+      "```",
+      "",
+      "```js",
+      "const x = 1;",
+      "```",
+      "",
+    ].join("\n");
+    const result = formatMarkdownContent(original);
+    expect(result.text).toBe(expected);
+    expect(result.found).toBe(1);
+    expect(result.changed).toBe(1);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("should support the puml fence info string", () => {
+    const original = ["```puml", "[B] -> [C]", "[A] -> [B]", "```", ""].join(
+      "\n"
+    );
+    const result = formatMarkdownContent(original);
+    expect(result.text).toContain("[A] -> [B]\n[B] -> [C]");
+    expect(result.found).toBe(1);
+  });
+
+  it("should format multiple plantuml blocks", () => {
+    const original = [
+      "```plantuml",
+      "[B] -> [C]",
+      "[A] -> [B]",
+      "```",
+      "text",
+      "```plantuml",
+      "[Y] -> [Z]",
+      "[X] -> [Y]",
+      "```",
+      "",
+    ].join("\n");
+    const result = formatMarkdownContent(original);
+    expect(result.found).toBe(2);
+    expect(result.changed).toBe(2);
+    expect(result.text.indexOf("[A] -> [B]")).toBeLessThan(
+      result.text.indexOf("[B] -> [C]")
+    );
+    expect(result.text.indexOf("[X] -> [Y]")).toBeLessThan(
+      result.text.indexOf("[Y] -> [Z]")
+    );
+  });
+
+  it("should not report changes for markdown without plantuml blocks", () => {
+    const original = "# Just text\n\nNothing to do here.\n";
+    const result = formatMarkdownContent(original);
+    expect(result.text).toBe(original);
+    expect(result.found).toBe(0);
+    expect(result.changed).toBe(0);
+  });
+
+  it("should warn about a block with unsupported content and keep it", () => {
+    const original = ["```plantuml", "(Use Case)", "```", ""].join("\n");
+    const result = formatMarkdownContent(original);
+    expect(result.text).toBe(original);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("diagram at line 2");
+  });
+
+  it("should warn about an unterminated plantuml block and keep the file", () => {
+    const original = ["```plantuml", "[A] -> [B]", ""].join("\n");
+    const result = formatMarkdownContent(original);
+    expect(result.text).toBe(original);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("unterminated");
+  });
+
+  it("should skip empty plantuml blocks", () => {
+    const original = ["```plantuml", "```", ""].join("\n");
+    const result = formatMarkdownContent(original);
+    expect(result.text).toBe(original);
+    expect(result.found).toBe(0);
+  });
+
+  it("should handle tilde fences and longer fences", () => {
+    const original = [
+      "~~~plantuml",
+      "[B] -> [C]",
+      "[A] -> [B]",
+      "~~~",
+      "````plantuml",
+      "[D] -> [E]",
+      "[C] -> [D]",
+      "````",
+      "",
+    ].join("\n");
+    const result = formatMarkdownContent(original);
+    expect(result.found).toBe(2);
+    expect(result.text.indexOf("[A] -> [B]")).toBeLessThan(
+      result.text.indexOf("[B] -> [C]")
+    );
+    expect(result.text.indexOf("[C] -> [D]")).toBeLessThan(
+      result.text.indexOf("[D] -> [E]")
+    );
+  });
+
+  it("should ignore plantuml-looking fences inside other code blocks", () => {
+    const original = [
+      "````md",
+      "```plantuml",
+      "[B] -> [C]",
+      "[A] -> [B]",
+      "```",
+      "````",
+      "",
+    ].join("\n");
+    const result = formatMarkdownContent(original);
+    // the outer ````md block ends at the first ```` line; the inner
+    // ```plantuml fence is closed by the ``` line, so nothing outside a
+    // md block is misinterpreted
+    expect(result.found).toBe(0);
+    expect(result.text).toBe(original);
+  });
+
+  it("should preserve CRLF line endings in markdown", () => {
+    const original = "```plantuml\r\n[B] -> [C]\r\n[A] -> [B]\r\n```\r\n";
+    const result = formatMarkdownContent(original);
+    expect(result.text).toBe(
+      "```plantuml\r\n[A] -> [B]\r\n[B] -> [C]\r\n```\r\n"
+    );
+  });
+});


### PR DESCRIPTION
Expose the extension's Auto Format and Reset Arrow Directions commands
as a standalone CLI (pumlfmt format / pumlfmt reset) working on .puml
files (including multi-diagram files) and on plantuml/puml fenced code
blocks in markdown files. Includes a --check mode for CI, an npm bin
entry, and an install.sh for Linux/macOS that builds the CLI and places
a launcher on the PATH.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015a8kE5pEFvMoKeZSZumwWw