### PR TITLE
Replace pumlsrv remote script install with pinned release verification

### DIFF
--- a/src/pumlsrvInstaller.ts
+++ b/src/pumlsrvInstaller.ts
@@ -1,0 +1,207 @@
+import * as child_process from "child_process";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as https from "https";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Pinned pumlsrv release installed by the extension.
+ *
+ * The jar is downloaded directly from the GitHub release and its sha256 is
+ * verified against the digest pinned here before anything is installed -
+ * no remote script is fetched or executed. A compromised upstream release
+ * therefore cannot reach users of this extension until this pin is
+ * deliberately updated.
+ *
+ * To upgrade: pick the new tag on
+ * https://github.com/michael72/pumlsrv/releases and copy the jar's sha256
+ * digest from
+ * `curl -s https://api.github.com/repos/michael72/pumlsrv/releases/latest`.
+ */
+export const PINNED_PUMLSRV = {
+  version: "v2.1.1",
+  jarName: "pumlsrv-2.1.1.jar",
+  sha256: "4726d8334644e793ad49d157d3f006f48a45777dee15f11880ee400321a23212",
+  // maven.compiler.target of the pinned release (see pumlsrv's pom.xml)
+  requiredJavaMajor: 25,
+} as const;
+
+export interface PumlsrvRelease {
+  version: string;
+  jarName: string;
+  sha256: string;
+}
+
+export function jarDownloadUrl(release: PumlsrvRelease): string {
+  return `https://github.com/michael72/pumlsrv/releases/download/${release.version}/${release.jarName}`;
+}
+
+/** Same locations get.sh uses, so both install methods find each other. */
+export function getPumlsrvDataDir(): string {
+  const env = globalThis.process.env;
+  const dataHome =
+    env["XDG_DATA_HOME"] ?? path.join(os.homedir(), ".local", "share");
+  return path.join(dataHome, "pumlsrv");
+}
+
+export function getPumlsrvBinDir(): string {
+  const env = globalThis.process.env;
+  return env["XDG_BIN_HOME"] ?? path.join(os.homedir(), ".local", "bin");
+}
+
+/** Launcher script content, identical to the one written by pumlsrv's get.sh. */
+export function launcherScript(dataDir: string, jarName: string): string {
+  return (
+    "#!/bin/bash\n" +
+    `cd "${dataDir}"\n` +
+    `java -cp "./${jarName}" com.github.michael72.pumlsrv.Main "$@"\n`
+  );
+}
+
+/** Extracts the major version from `java -version` output, e.g. 21 from
+ *  `openjdk version "21.0.10"` or 8 from `java version "1.8.0_392"`. */
+export function parseJavaMajorVersion(versionOutput: string): number | undefined {
+  const match = /version "(\d+)(?:\.(\d+))?/.exec(versionOutput);
+  if (!match) {
+    return undefined;
+  }
+  const first = Number(match[1]);
+  // Pre-9 JDKs report "1.x"
+  return first === 1 && match[2] !== undefined ? Number(match[2]) : first;
+}
+
+export async function sha256OfFile(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => {
+      resolve(hash.digest("hex"));
+    });
+    stream.on("error", reject);
+  });
+}
+
+/* v8 ignore start */
+function assertJavaAvailable(): void {
+  // java -version prints its version to stderr
+  const result = child_process.spawnSync("java", ["-version"], {
+    encoding: "utf-8",
+    timeout: 10000,
+  });
+  if (result.error !== undefined || result.status !== 0) {
+    throw new Error(
+      "Java is required to run pumlsrv but was not found on PATH."
+    );
+  }
+  const major = parseJavaMajorVersion(result.stderr + result.stdout);
+  if (major !== undefined && major < PINNED_PUMLSRV.requiredJavaMajor) {
+    throw new Error(
+      `pumlsrv ${PINNED_PUMLSRV.version} requires Java ` +
+        `${PINNED_PUMLSRV.requiredJavaMajor.toString()} or newer, ` +
+        `but Java ${major.toString()} was found on PATH.`
+    );
+  }
+}
+
+async function httpsDownload(
+  url: string,
+  dest: string,
+  maxRedirects = 5
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = https.get(
+      url,
+      { headers: { "User-Agent": "plantuml-helpers" }, timeout: 30000 },
+      (res) => {
+        const status = res.statusCode ?? 0;
+        const location = res.headers.location;
+        if (status >= 300 && status < 400 && location !== undefined) {
+          res.resume();
+          if (maxRedirects <= 0) {
+            reject(new Error(`Too many redirects while downloading ${url}`));
+            return;
+          }
+          const next = new URL(location, url).toString();
+          if (!next.startsWith("https://")) {
+            reject(new Error(`Refusing insecure redirect to ${next}`));
+            return;
+          }
+          httpsDownload(next, dest, maxRedirects - 1).then(resolve, reject);
+          return;
+        }
+        if (status !== 200) {
+          res.resume();
+          reject(new Error(`Download failed with HTTP ${status.toString()}: ${url}`));
+          return;
+        }
+        const out = fs.createWriteStream(dest);
+        res.pipe(out);
+        out.on("finish", () => {
+          out.close(() => {
+            resolve();
+          });
+        });
+        out.on("error", (err) => {
+          res.destroy();
+          reject(err);
+        });
+        res.on("error", (err) => {
+          out.destroy();
+          reject(err);
+        });
+      }
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error(`Download timed out: ${url}`));
+    });
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Downloads the pinned pumlsrv release jar, verifies its sha256 against the
+ * pinned digest and installs jar + launcher script. Replaces the previous
+ * `curl ... | bash` install, which executed a remote script without any
+ * integrity check.
+ */
+export async function installPinnedPumlsrv(): Promise<void> {
+  if (globalThis.process.platform === "win32") {
+    throw new Error(
+      "Automatic pumlsrv installation is not supported on Windows. " +
+        "See https://github.com/michael72/pumlsrv for manual installation."
+    );
+  }
+  assertJavaAvailable();
+
+  const dataDir = getPumlsrvDataDir();
+  const binDir = getPumlsrvBinDir();
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(binDir, { recursive: true });
+
+  const jarPath = path.join(dataDir, PINNED_PUMLSRV.jarName);
+  const tmpPath = path.join(
+    dataDir,
+    `.${PINNED_PUMLSRV.jarName}.${globalThis.process.pid.toString()}.tmp`
+  );
+  try {
+    await httpsDownload(jarDownloadUrl(PINNED_PUMLSRV), tmpPath);
+    const actual = await sha256OfFile(tmpPath);
+    if (actual.toLowerCase() !== PINNED_PUMLSRV.sha256.toLowerCase()) {
+      throw new Error(
+        `Checksum mismatch for ${PINNED_PUMLSRV.jarName}: ` +
+          `expected ${PINNED_PUMLSRV.sha256}, got ${actual}. ` +
+          "The download was discarded."
+      );
+    }
+    fs.renameSync(tmpPath, jarPath);
+  } finally {
+    fs.rmSync(tmpPath, { force: true });
+  }
+
+  const launcher = path.join(binDir, "pumlsrv");
+  fs.writeFileSync(launcher, launcherScript(dataDir, PINNED_PUMLSRV.jarName));
+  fs.chmodSync(launcher, 0o755);
+}
+/* v8 ignore stop */

--- a/src/pumlsrvService.ts
+++ b/src/pumlsrvService.ts
@@ -3,10 +3,10 @@ import * as vscode from "vscode";
 import * as http from "http";
 import * as net from "net";
 import * as child_process from "child_process";
-import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
 import { encodePlantUml } from "./plantumlEncoder.js";
+import { getPumlsrvBinDir, installPinnedPumlsrv } from "./pumlsrvInstaller.js";
 
 const HELLO_WORLD_PUML = "@startuml\nAlice -> Bob: Hello\n@enduml";
 
@@ -76,11 +76,6 @@ async function checkPumlsrvRunning(port: number): Promise<boolean> {
   });
 }
 
-function getPumlsrvBinDir(): string {
-  const env = globalThis.process.env;
-  return env["XDG_BIN_HOME"] ?? path.join(os.homedir(), ".local", "bin");
-}
-
 function findPumlsrvBinary(): string | undefined {
   // Check PATH via 'which' (execFileSync avoids spawning a shell)
   try {
@@ -103,37 +98,6 @@ function findPumlsrvBinary(): string | undefined {
   return undefined;
 }
 
-async function installPumlsrv(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const proc = child_process.spawn(
-      "bash",
-      [
-        "-c",
-        "curl -sSL https://raw.githubusercontent.com/michael72/pumlsrv/master/get.sh | bash",
-      ],
-      { stdio: ["pipe", "pipe", "pipe"] }
-    );
-
-    // The install script asks whether to start pumlsrv - answer "n"
-    proc.stdin?.write("n\n");
-    proc.stdin?.end();
-
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(
-          new Error(
-            `pumlsrv installation failed with exit code ${code?.toString() ?? "unknown"}`
-          )
-        );
-      }
-    });
-
-    proc.on("error", reject);
-  });
-}
-
 async function runInstallWithProgress(): Promise<void> {
   await vscode.window.withProgress(
     {
@@ -142,7 +106,7 @@ async function runInstallWithProgress(): Promise<void> {
       cancellable: false,
     },
     async () => {
-      await installPumlsrv();
+      await installPinnedPumlsrv();
     }
   );
 }
@@ -156,7 +120,14 @@ export async function installPumlsrvManually(): Promise<void> {
     void vscode.window.showInformationMessage("pumlsrv is already installed.");
     return;
   }
-  await runInstallWithProgress();
+  try {
+    await runInstallWithProgress();
+  } catch (err) {
+    void vscode.window.showErrorMessage(
+      `pumlsrv installation failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return;
+  }
   if (findPumlsrvBinary() === undefined) {
     void vscode.window.showErrorMessage(
       `pumlsrv installation failed: binary not found after install. ` +

--- a/test/pumlsrvInstaller.spec.ts
+++ b/test/pumlsrvInstaller.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  PINNED_PUMLSRV,
+  jarDownloadUrl,
+  launcherScript,
+  parseJavaMajorVersion,
+  sha256OfFile,
+  getPumlsrvBinDir,
+  getPumlsrvDataDir,
+} from "../src/pumlsrvInstaller.js";
+
+describe("pumlsrvInstaller", () => {
+  describe("PINNED_PUMLSRV", () => {
+    it("should pin a full sha256 digest in lowercase hex", () => {
+      expect(PINNED_PUMLSRV.sha256).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("should pin a jar matching the pinned version", () => {
+      const bareVersion = PINNED_PUMLSRV.version.replace(/^v/, "");
+      expect(PINNED_PUMLSRV.jarName).toBe(`pumlsrv-${bareVersion}.jar`);
+    });
+  });
+
+  describe("jarDownloadUrl", () => {
+    it("should build the GitHub release download URL for the pinned jar", () => {
+      expect(jarDownloadUrl(PINNED_PUMLSRV)).toBe(
+        "https://github.com/michael72/pumlsrv/releases/download/" +
+          `${PINNED_PUMLSRV.version}/${PINNED_PUMLSRV.jarName}`
+      );
+    });
+  });
+
+  describe("launcherScript", () => {
+    it("should produce the same launcher get.sh writes", () => {
+      const script = launcherScript("/home/user/.local/share/pumlsrv", "x.jar");
+      expect(script).toBe(
+        "#!/bin/bash\n" +
+          'cd "/home/user/.local/share/pumlsrv"\n' +
+          'java -cp "./x.jar" com.github.michael72.pumlsrv.Main "$@"\n'
+      );
+    });
+  });
+
+  describe("parseJavaMajorVersion", () => {
+    it("should parse modern java version output", () => {
+      expect(
+        parseJavaMajorVersion('openjdk version "21.0.10" 2026-01-20')
+      ).toBe(21);
+      expect(parseJavaMajorVersion('java version "25" 2025-09-16')).toBe(25);
+    });
+
+    it("should parse pre-9 java version output", () => {
+      expect(parseJavaMajorVersion('java version "1.8.0_392"')).toBe(8);
+    });
+
+    it("should return undefined for unrecognized output", () => {
+      expect(parseJavaMajorVersion("no version here")).toBeUndefined();
+    });
+  });
+
+  describe("sha256OfFile", () => {
+    it("should compute the sha256 of a file as lowercase hex", async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pumlsrv-test-"));
+      const file = path.join(dir, "data.bin");
+      try {
+        fs.writeFileSync(file, "abc");
+        await expect(sha256OfFile(file)).resolves.toBe(
+          "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("should reject for a missing file", async () => {
+      await expect(sha256OfFile("/nonexistent/nowhere.bin")).rejects.toThrow();
+    });
+  });
+
+  describe("install directories", () => {
+    const savedBin = process.env["XDG_BIN_HOME"];
+    const savedData = process.env["XDG_DATA_HOME"];
+
+    afterEach(() => {
+      if (savedBin === undefined) {
+        delete process.env["XDG_BIN_HOME"];
+      } else {
+        process.env["XDG_BIN_HOME"] = savedBin;
+      }
+      if (savedData === undefined) {
+        delete process.env["XDG_DATA_HOME"];
+      } else {
+        process.env["XDG_DATA_HOME"] = savedData;
+      }
+    });
+
+    it("should honor XDG_BIN_HOME and XDG_DATA_HOME", () => {
+      process.env["XDG_BIN_HOME"] = "/custom/bin";
+      process.env["XDG_DATA_HOME"] = "/custom/share";
+      expect(getPumlsrvBinDir()).toBe("/custom/bin");
+      expect(getPumlsrvDataDir()).toBe(path.join("/custom/share", "pumlsrv"));
+    });
+
+    it("should fall back to ~/.local defaults", () => {
+      delete process.env["XDG_BIN_HOME"];
+      delete process.env["XDG_DATA_HOME"];
+      expect(getPumlsrvBinDir()).toBe(
+        path.join(os.homedir(), ".local", "bin")
+      );
+      expect(getPumlsrvDataDir()).toBe(
+        path.join(os.homedir(), ".local", "share", "pumlsrv")
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Replace the unsafe `curl | bash` installation method for pumlsrv with a secure, pinned release approach that downloads and verifies the jar file's SHA256 checksum before installation.

## Key Changes
- **New `pumlsrvInstaller.ts` module**: Implements secure pumlsrv installation with:
  - Pinned release version (v2.1.1) with hardcoded SHA256 digest for integrity verification
  - Direct HTTPS download of the jar file from GitHub releases
  - SHA256 checksum validation before installation
  - Java version detection and validation (requires Java 25+)
  - Launcher script generation compatible with the original `get.sh` script
  - XDG Base Directory specification support for install locations
  
- **Updated `pumlsrvService.ts`**:
  - Removed inline `installPumlsrv()` function that executed remote bash script
  - Removed duplicate `getPumlsrvBinDir()` function (now imported from installer module)
  - Replaced `curl | bash` call with `installPinnedPumlsrv()` from new module
  - Added error handling to display installation failures to the user

- **Comprehensive test suite** (`pumlsrvInstaller.spec.ts`):
  - Validates pinned release metadata (SHA256 format, jar name consistency)
  - Tests URL generation, launcher script generation, and Java version parsing
  - Tests SHA256 file computation and directory resolution with XDG environment variables

## Notable Implementation Details
- Downloads to a temporary file with process ID suffix before atomic rename, preventing partial installations
- Validates Java availability and version before attempting download
- Supports HTTPS redirects with security checks (rejects insecure redirects)
- Implements 30-second download timeout and proper error cleanup
- Windows installation explicitly unsupported with helpful error message
- Installation directories follow XDG Base Directory specification with `~/.local` fallbacks

https://claude.ai/code/session_01CGQBbVyJLCDEdsEjZ3nhF4